### PR TITLE
Handle quotes in error message for invalid token

### DIFF
--- a/source/request.ts
+++ b/source/request.ts
@@ -26,7 +26,7 @@ export function handleBadResponse(response: Response): void {
             throw new Layerr({
                 cause: error,
                 info: {
-                    authFailure: /error=invalid_token/.test(response.headers.get("www-authenticate"))
+                    authFailure: /error="invalid_token"/.test(response.headers.get("www-authenticate"))
                 }
             }, "Bad authentication");
         }

--- a/test/unit/fileContents.spec.js
+++ b/test/unit/fileContents.spec.js
@@ -61,7 +61,7 @@ describe("fileContents", function() {
                 ),
                 ok: false,
                 headers: new Headers({
-                    "www-authenticate": `Bearer realm="https://accounts.google.com/", error=invalid_token`
+                    "www-authenticate": `Bearer realm="https://accounts.google.com/", error="invalid_token"`
                 }),
                 status: 401,
                 statusText: "Unauthorized"


### PR DESCRIPTION
Hi :)

First of all thanks for Buttercup, it's an awesome tool!

I try to fix this issue: https://github.com/buttercup/buttercup-desktop/issues/1188 