### PR TITLE
Add support for Google shared drive items

### DIFF
--- a/source/requests/createDirectory.ts
+++ b/source/requests/createDirectory.ts
@@ -19,6 +19,9 @@ export async function createDirectory(options: InternalCreateDirectoryOptions): 
     const config: RequestConfig = {
         url: URL_CREATE_DIRECTORY,
         method: "POST",
+        query: {
+            supportsAllDrives: "true"
+        },
         headers: {
             Authorization: `Bearer ${token}`,
             "Content-Type": "application/json"

--- a/source/requests/deleteFile.ts
+++ b/source/requests/deleteFile.ts
@@ -13,6 +13,9 @@ export async function deleteFile(options: InternalDeleteFileOptions): Promise<vo
     const config: RequestConfig = {
         url: `https://www.googleapis.com/drive/v3/files/${options.id}`,
         method: "DELETE",
+        query: {
+            supportsAllDrives: "true"
+        },
         headers: {
             Authorization: `Bearer ${options.token}`
         }

--- a/source/requests/getDirectoryContents.ts
+++ b/source/requests/getDirectoryContents.ts
@@ -40,9 +40,11 @@ export async function getDirectoryContents(
         url: "https://www.googleapis.com/drive/v3/files",
         method: "GET",
         query: {
-            corpora: "user",
+            corpora: "allDrives",
+            includeItemsFromAllDrives: "true",
             pageSize: "1000",
             spaces: "drive",
+            supportsAllDrives: "true",
             fields: "files(id,name,mimeType,createdTime,modifiedTime,shared,size,parents,trashed),nextPageToken"
         },
         headers: {

--- a/source/requests/getFileContents.ts
+++ b/source/requests/getFileContents.ts
@@ -14,7 +14,8 @@ export async function getFileContents(options: InternalGetFileContentsOptions): 
         url: `https://www.googleapis.com/drive/v3/files/${options.id}`,
         method: "GET",
         query: {
-            alt: "media"
+            alt: "media",
+            supportsAllDrives: "true"
         },
         headers: {
             Authorization: `Bearer ${options.token}`

--- a/source/requests/putFileContents.ts
+++ b/source/requests/putFileContents.ts
@@ -71,7 +71,8 @@ export async function putFileContents(options: InternalPutFileContentsOptions): 
         url,
         method,
         query: {
-            uploadType: "multipart"
+            uploadType: "multipart",
+            supportsAllDrives: "true"
         },
         headers: {
             Authorization: `Bearer ${token}`,


### PR DESCRIPTION
This should add feature request https://github.com/buttercup/googledrive-client/issues/15

This adds supportsAllDrives and includeItemsFromAllDrives parameters where needed. We also need to change corpora parameter from "user" to "allDrives" so Googledrive-client can list all shared drive items that the user can be member of.

Signed-off-by: Alexandre Demers <alexandre.f.demers@gmail.com>